### PR TITLE
update tests, bump deps, support only node >= 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,21 +2,19 @@ dist: trusty
 sudo: required
 language: node_js
 node_js:
+  - '10'
+  - '9'
   - '8'
   - '7'
   - '6'
   - '5'
   - '4'
-  - 'iojs'
-  - '0.12'
-  - '0.11'
-  - '0.10'
 before_install:
   - sudo apt-get -qq update
   - wget -q https://downloads.sourceforge.net/project/fis-gtm/GT.M-amd64-Linux/V6.3-002/gtm_V63002_linux_x8664_pro.tar.gz -P /home/travis
   - mkdir ~/gtm_V63002_linux_x8664_pro
   - tar zxvf ~/gtm_V63002_linux_x8664_pro.tar.gz -C ~/gtm_V63002_linux_x8664_pro
-  - (cd /home/travis/gtm_V63002_linux_x8664_pro && sudo ./gtminstall --distrib /home/travis/gtm_V63002_linux_x8664_pro)
+  - (cd ~/gtm_V63002_linux_x8664_pro && sudo ./gtminstall --distrib ~/gtm_V63002_linux_x8664_pro --verbose)
   - /usr/lib/fis-gtm/V6.3-002_x86_64/gtmprofile
   - /usr/lib/fis-gtm/V6.3-002_x86_64/gtmbase
 script:

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Integrates the GT.M database with ewd-qoper8 worker processes",
   "license": "Apache-2.0",
   "main": "index.js",
+  "engines": {
+    "node": ">=4"
+  },
   "author": "Rob Tweed, M/Gateway Developments Ltd",
   "homepage": "https://github.com/robtweed/ewd-qoper8-gtm#readme",
   "repository": {
@@ -35,20 +38,20 @@
     ]
   },
   "dependencies": {
-    "ewd-document-store": "^1.18.0"
+    "ewd-document-store": "^1.23.0"
   },
   "devDependencies": {
     "body-parser": "^1.18.2",
-    "coveralls": "^2.13.1",
-    "dotenv": "^4.0.0",
+    "coveralls": "^3.0.2",
+    "dotenv": "^6.0.0",
     "ewd-qoper8": "^3.16.0",
     "express": "^4.15.5",
-    "jasmine": "^2.8.0",
+    "jasmine": "^3.1.0",
     "jasmine-spec-reporter": "^4.1.1",
     "jshint": "^2.9.5",
     "mockery": "^2.1.0",
     "nodem": "^0.9.2",
-    "nyc": "^11.1.0",
+    "nyc": "^12.0.2",
     "pre-commit": "^1.2.2",
     "supertest": "^3.0.0"
   }

--- a/spec/unit/gtm.spec.js
+++ b/spec/unit/gtm.spec.js
@@ -83,7 +83,7 @@ describe('unit/gtm:', function () {
 
       worker.emit('stop');
 
-      expect(db.close).toHaveBeenCalled();
+      expect(db.close).toHaveBeenCalledWith({resetTerminal: true});
       expect(spy).toHaveBeenCalled();
     });
   });
@@ -103,7 +103,7 @@ describe('unit/gtm:', function () {
 
       worker.emit('unexpectedError');
 
-      expect(db.close).toHaveBeenCalled();
+      expect(db.close).toHaveBeenCalledWith({resetTerminal: true});
     });
 
     it('handle unexpected error when db is not initialized', function () {
@@ -138,20 +138,37 @@ describe('unit/gtm:', function () {
   });
 
   describe('environment', function () {
-    it('environment.nodem', function () {
-      var customDb = gtmMock.mock();
-      var CustomGtm = jasmine.createSpy().and.returnValue(customDb);
-      mockery.registerMock('/path/to/nodem', {
-        Gtm: CustomGtm
+    describe('open_params', function () {
+      it('should call db.open with correct params', function () {
+        var openParams = {foo: 'bar'};
+        /*jshint camelcase: false */
+        var environment = {
+          open_params: openParams
+        };
+        /*jshint camelcase: true */
+
+        gtm(worker, environment);
+
+        expect(worker.db.open).toHaveBeenCalledWith(openParams);
       });
+    });
 
-      var environment = {
-        nodem: '/path/to/nodem'
-      };
+    describe('nodem', function () {
+      it('should use custom path to nodem', function () {
+        var customDb = gtmMock.mock();
+        var CustomGtm = jasmine.createSpy().and.returnValue(customDb);
+        mockery.registerMock('/path/to/nodem', {
+          Gtm: CustomGtm
+        });
 
-      gtm(worker, environment);
+        var environment = {
+          nodem: '/path/to/nodem'
+        };
 
-      expect(worker.db).toBe(customDb);
+        gtm(worker, environment);
+
+        expect(worker.db).toBe(customDb);
+      });
     });
 
     it('should set environment', function () {

--- a/spec/unit/setEnvironment.spec.js
+++ b/spec/unit/setEnvironment.spec.js
@@ -70,4 +70,22 @@ describe('unit/setEnvironment:', function () {
     expect(process.env['gtmroutines']).toBe('/tmp/gtmdir/V6.3-002_x86/o(/tmp/gtmdir/V6.3-002_x86/r /tmp/gtmdir/r) /usr/local/lib/fis-gtm/V6.3-002 ' + DIR + '/node_modules/nodem/src');
     /*jshint sub: false */
   });
+
+  it('should set environment variables from params.ydb_env', function () {
+    /*jshint camelcase: false */
+    var params = {
+      ydb_env: {
+        ydb_retention: 42,
+        ydb_log: '/tmp/yottadb/r1.22_x86_64'
+      }
+    };
+    /*jshint camelcase: true */
+
+    setEnvironment(params);
+
+     /*jshint sub: true */
+    expect(process.env['ydb_retention']).toBe('42');
+    expect(process.env['ydb_log']).toBe('/tmp/yottadb/r1.22_x86_64');
+    /*jshint sub: false */
+  });
 });


### PR DESCRIPTION
Summary:

 - update tests
 - bump deps (except nodem, because I got problem with configuring gtm on travis)
 - support only node 4+